### PR TITLE
Lenient BedParser

### DIFF
--- a/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
@@ -13,9 +13,9 @@ import org.jetbrains.bio.genome.Location
 import org.jetbrains.bio.genome.containers.LocationsMergingList
 import org.jetbrains.bio.genome.toStrand
 import org.jetbrains.bio.io.BedFormat.Companion.auto
-import org.jetbrains.bio.io.BedParser.Companion.Leniency
-import org.jetbrains.bio.io.BedParser.Companion.Leniency.LENIENT
-import org.jetbrains.bio.io.BedParser.Companion.Leniency.STRICT
+import org.jetbrains.bio.io.BedParser.Companion.Stringency
+import org.jetbrains.bio.io.BedParser.Companion.Stringency.LENIENT
+import org.jetbrains.bio.io.BedParser.Companion.Stringency.STRICT
 import org.jetbrains.bio.util.*
 import java.awt.Color
 import java.io.*
@@ -305,13 +305,13 @@ data class BedFormat(
 /**
  * Reads [BedEntry]-s from the supplied [reader].
  *
- * Set [leniency] to your preferred mode before starting to parse. See [Leniency] for mode explanation.
+ * Set [stringency] to your preferred mode before starting to parse. See [Stringency] for mode explanation.
  */
 class BedParser(
         internal val reader: BufferedReader,
         private val source: String,
         val separator: Char,
-        var leniency: Leniency = LENIENT
+        var stringency: Stringency = LENIENT
 ): Iterable<BedEntry>, AutoCloseable {
 
     private val splitter = Splitter.on(separator).limit(4).trimResults().omitEmptyStrings()
@@ -332,7 +332,7 @@ class BedParser(
     }
 
     /**
-     * Parses the next line. Depending on [leniency], either throws [BedFormatException]
+     * Parses the next line. Depending on [stringency], either throws [BedFormatException]
      * or keeps going on parsing errors.
      * @return the parsed entry or null if there are no more lines to parse.
      */
@@ -343,7 +343,7 @@ class BedParser(
                 return parse(line)
             } catch (e: IllegalArgumentException) {
                 val message = "$source: failed to parse BED line:\n$line"
-                when (leniency) {
+                when (stringency) {
                     STRICT -> throw BedFormatException(message, e)
                     LENIENT -> LOG.debug(message, e)
                 }
@@ -389,7 +389,7 @@ class BedParser(
          * [STRICT] parser throws a [BedFormatException] on lines it can't parse.
          * [LENIENT] parser just logs the error and continues.
          */
-        enum class Leniency {
+        enum class Stringency {
             STRICT, LENIENT
         }
     }

--- a/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
@@ -311,9 +311,9 @@ data class BedFormat(
  *          parser.forEach { bedEntry -> println(bedEntry) }
  *      }
  *
- * @param reader The reader that provides lines to convert into [BedEntry]-s.
- * @param source The BED source description, used in log and exception messages.
- * @param separator The separator character for line parsing.
+ * @property reader The reader that provides lines to convert into [BedEntry]-s.
+ * @property source The BED source description, used in log and exception messages.
+ * @property separator The separator character for line parsing.
  *
  * @property stringency controls the parser stringency (see [Stringency] for detailed explanation).
  * It can be changed at any time:

--- a/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
@@ -305,18 +305,33 @@ data class BedFormat(
 /**
  * Reads [BedEntry]-s from the supplied [reader].
  *
- * Set [stringency] to your preferred mode before starting to parse. See [Stringency] for mode explanation.
+ * [BedParser] is usually used via [BedFormat.parse] method. It implements [Iterable] over [BedEntry],
+ * so it's normally a receiver of [map] or [forEach] calls:
+ *      bedFormat.parse(file) { parser ->
+ *          parser.forEach { bedEntry -> println(bedEntry) }
+ *      }
  *
- * Use [linesFailedToParse] property to find out how many lines were skipped due to parsing errors.
+ * @param reader The reader that provides lines to convert into [BedEntry]-s.
+ * @param source The BED source description, used in log and exception messages.
+ * @param separator The separator character for line parsing.
+ *
+ * @property stringency controls the parser stringency (see [Stringency] for detailed explanation).
+ * It can be changed at any time:
+ *      parser.stringency = Stringency.STRICT
+ * It's set to [LENIENT] by default.
+ *
+ * @property linesFailedToParse shows how many lines were skipped due to parsing errors. Note that it's useless
+ * with [stringency] == [STRICT], since the parser will throw on any line that fails to parse.
  */
 class BedParser(
         internal val reader: BufferedReader,
         private val source: String,
-        val separator: Char,
-        var stringency: Stringency = LENIENT
+        val separator: Char
 ): Iterable<BedEntry>, AutoCloseable {
 
     private val splitter = Splitter.on(separator).limit(4).trimResults().omitEmptyStrings()
+
+    var stringency = LENIENT
 
     var linesFailedToParse: Int = 0
         private set

--- a/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
@@ -311,7 +311,7 @@ class BedParser(
         internal val reader: BufferedReader,
         private val source: String,
         val separator: Char,
-        var leniency: Leniency = STRICT
+        var leniency: Leniency = LENIENT
 ): Iterable<BedEntry>, AutoCloseable {
 
     private val splitter = Splitter.on(separator).limit(4).trimResults().omitEmptyStrings()

--- a/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
+++ b/src/main/kotlin/org/jetbrains/bio/io/Bed.kt
@@ -13,6 +13,7 @@ import org.jetbrains.bio.genome.Location
 import org.jetbrains.bio.genome.containers.LocationsMergingList
 import org.jetbrains.bio.genome.toStrand
 import org.jetbrains.bio.io.BedFormat.Companion.auto
+import org.jetbrains.bio.io.BedParser.Companion.Leniency
 import org.jetbrains.bio.io.BedParser.Companion.Leniency.LENIENT
 import org.jetbrains.bio.io.BedParser.Companion.Leniency.STRICT
 import org.jetbrains.bio.util.*
@@ -303,6 +304,8 @@ data class BedFormat(
 
 /**
  * Reads [BedEntry]-s from the supplied [reader].
+ *
+ * Set [leniency] to your preferred mode before starting to parse. See [Leniency] for mode explanation.
  */
 class BedParser(
         internal val reader: BufferedReader,
@@ -383,7 +386,7 @@ class BedParser(
         private val LOG = Logger.getLogger(BedParser::class.java)
 
         /**
-         * [STRICT] parser throws a [BedFormatException] on entries it can't parse.
+         * [STRICT] parser throws a [BedFormatException] on lines it can't parse.
          * [LENIENT] parser just logs the error and continues.
          */
         enum class Leniency {

--- a/src/test/kotlin/org/jetbrains/bio/io/BedParserTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/io/BedParserTest.kt
@@ -392,7 +392,9 @@ Fields number in BED file is between 3 and 15, but was 2""")
         withBedFile(incorrectBed) { path ->
             val entries = BedFormat.auto(path).parse(path) {
                 it.stringency = BedParser.Companion.Stringency.LENIENT
-                it.toList()
+                val res = it.toList()
+                assertEquals(1, it.linesFailedToParse)
+                res
             }
             assertEquals(1, entries.size)
         }
@@ -638,10 +640,10 @@ Fields number in BED file is between 3 and 15, but was 2""")
 
             require(BedFormat.from("bed4+1", '\t') == format)
 
-            val entries = format.parse(path) {
-                it.use { p ->
-                    p.toList()
-                }
+            val entries = format.parse(path) { p ->
+                val res = p.toList()
+                assertEquals(1, p.linesFailedToParse)
+                res
             }
             val genome = Genome["to1"]
 
@@ -662,7 +664,7 @@ Fields number in BED file is between 3 and 15, but was 2""")
         assertFalse(BedField.ITEM_RGB in BedFormat.from("bed8"))
     }
 
-    @Test fun bedFormatFromFiled() {
+    @Test fun bedFormatFromField() {
         assertEquals("bed6", BedFormat(BedField.STRAND).fmtStr)
         assertEquals("bed9", BedFormat(BedField.ITEM_RGB).fmtStr)
     }

--- a/src/test/kotlin/org/jetbrains/bio/io/BedParserTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/io/BedParserTest.kt
@@ -375,6 +375,29 @@ Fields number in BED file is between 3 and 15, but was 2""")
         }
     }
 
+    @Test(expected = BedFormatException::class)
+    fun testParse_Strict() {
+        val incorrectBed = "chr start end score\nchr1 1 10 100"
+        withBedFile(incorrectBed) { path ->
+            BedFormat.auto(path).parse(path) {
+                it.leniency = BedParser.Companion.Leniency.STRICT
+                it.toList()
+            }
+        }
+    }
+
+    @Test
+    fun testParse_Lenient() {
+        val incorrectBed = "chr start end score\nchr1 1 10 100"
+        withBedFile(incorrectBed) { path ->
+            val entries = BedFormat.auto(path).parse(path) {
+                it.leniency = BedParser.Companion.Leniency.LENIENT
+                it.toList()
+            }
+            assertEquals(1, entries.size)
+        }
+    }
+
     @Test
     fun testAuto_WhitespaceSep() {
         doCheckAuto("chr2 1 2 Description 960 + 1000 5000 0 2 10,20, 1,2",

--- a/src/test/kotlin/org/jetbrains/bio/io/BedParserTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/io/BedParserTest.kt
@@ -380,7 +380,7 @@ Fields number in BED file is between 3 and 15, but was 2""")
         val incorrectBed = "chr start end score\nchr1 1 10 100"
         withBedFile(incorrectBed) { path ->
             BedFormat.auto(path).parse(path) {
-                it.leniency = BedParser.Companion.Leniency.STRICT
+                it.stringency = BedParser.Companion.Stringency.STRICT
                 it.toList()
             }
         }
@@ -391,7 +391,7 @@ Fields number in BED file is between 3 and 15, but was 2""")
         val incorrectBed = "chr start end score\nchr1 1 10 100"
         withBedFile(incorrectBed) { path ->
             val entries = BedFormat.auto(path).parse(path) {
-                it.leniency = BedParser.Companion.Leniency.LENIENT
+                it.stringency = BedParser.Companion.Stringency.LENIENT
                 it.toList()
             }
             assertEquals(1, entries.size)


### PR DESCRIPTION
Related to JetBrains-Research/jbr#62.

`BedParser` now has stringency property. In lenient mode (default), the parser skips any lines it can't parse (it also logs them with debug level). In strict mode, the parser throws an exception on any such line. This new feature is covered by tests.

Note: It's actually arguable whether we need strict mode at all. Thoughts are welcome.